### PR TITLE
Add register link to login page

### DIFF
--- a/src/pages/Login/Login.module.scss
+++ b/src/pages/Login/Login.module.scss
@@ -14,9 +14,13 @@
       }
     
       button {
-        background: var(--color-primary);
-        color: #fff;
-        cursor: pointer;
+            background: var(--color-primary);
+            color: #fff;
+            cursor: pointer;
       }
-    }
+}
+
+.registerLink {
+      text-align: center;
+}
     

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '../../store/auth';
 import cls from './Login.module.scss';
 
@@ -8,6 +9,7 @@ const Login = () => {
       const [password, setPassword] = useState('');
       const login = useAuthStore((s) => s.login);
       const nav = useNavigate();
+      const { t } = useTranslation();
 
       const submit = async (e: React.FormEvent) => {
             e.preventDefault();
@@ -33,6 +35,10 @@ const Login = () => {
                         onChange={(e) => setPassword(e.target.value)}
                   />
                   <button type="submit">Login</button>
+                  <p className={cls.registerLink}>
+                        {t('noAccount')}{' '}
+                        <Link to="/register">{t('createAccount')}</Link>
+                  </p>
             </form>
       );
 };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -17,6 +17,8 @@
         "painter": "Painter",
         "carpenter": "Carpenter",
         "other": "Other"
-      }
-    }
+      },
+      "createAccount": "Create an account",
+      "noAccount": "No account yet?"
+}
     

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -16,7 +16,9 @@
         "maid": "Femme de ménage",
         "painter": "Peintre",
         "carpenter": "Charpentier",
-        "other": "Autre"
-      }
-    }
+      "other": "Autre"
+    },
+    "createAccount": "Créer un compte",
+    "noAccount": "Pas encore de compte ?"
+  }
     


### PR DESCRIPTION
## Summary
- add translation keys for registration link
- style registration hint in Login page
- include registration link on Login page with i18n support

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685529f4fb54833083812fd85390d318