### PR TITLE
Add comprehensive registration form

### DIFF
--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -1,16 +1,50 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { api } from '../../services/api';
 import cls from './Register.module.scss';
 
 const Register = () => {
+      const { t } = useTranslation();
+
+      const quartiers = [
+            'Mendong',
+            'Odja',
+            'Nsam',
+            'Etoudi',
+            'Bastos',
+            'Bonamoussadi',
+            'Akwa',
+            'Bonanjo',
+            'Makepe',
+            'Essos',
+            'Mvog-Mbi',
+            'Emana',
+            'Nlongkak',
+            'Biyem-Assi',
+            'Autre'
+      ];
+      const professions = [
+            'plumber',
+            'electrician',
+            'hairdresser',
+            'mechanic',
+            'maid',
+            'painter',
+            'carpenter',
+            'other'
+      ];
       const [form, setForm] = useState({
+            gender: 'male',
             name: '',
             email: '',
             phone: '',
             password: '',
             role: 'client',
-            profession: 'plumber',
-            gender: 'male'
+            profession: professions[0],
+            momoNumber: '',
+            quartier: quartiers[0],
+            city: 'Yaoundé',
+            country: 'Cameroun'
       });
       const [photo, setPhoto] = useState<File | null>(null);
 
@@ -28,8 +62,121 @@ const Register = () => {
       return (
             <form className={cls.form} onSubmit={submit}>
                   <h1>Register</h1>
-                  {/* ... autres inputs ... */}
-                  <input type="file" accept="image/*" onChange={(e) => setPhoto(e.target.files?.[0] || null)} />
+
+                  <div className={cls.fieldsGrid}>
+                        <select
+                              value={form.gender}
+                              onChange={(e) => setForm((f) => ({ ...f, gender: e.target.value }))}
+                        >
+                              <option value="male">Male</option>
+                              <option value="female">Female</option>
+                              <option value="other">Other</option>
+                        </select>
+
+                        <input
+                              type="text"
+                              placeholder="Name"
+                              required
+                              value={form.name}
+                              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                        />
+
+                        <input
+                              type="email"
+                              placeholder="Email"
+                              required
+                              value={form.email}
+                              onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))}
+                        />
+
+                        <input
+                              type="tel"
+                              placeholder="Phone"
+                              required
+                              value={form.phone}
+                              onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))}
+                        />
+
+                        <input
+                              type="password"
+                              placeholder="Password"
+                              required
+                              value={form.password}
+                              onChange={(e) => setForm((f) => ({ ...f, password: e.target.value }))}
+                        />
+
+                        <select
+                              value={form.role}
+                              onChange={(e) => setForm((f) => ({ ...f, role: e.target.value }))}
+                        >
+                              <option value="client">Client</option>
+                              <option value="provider">Provider</option>
+                        </select>
+
+                        {form.role === 'provider' && (
+                              <>
+                                    <select
+                                          value={form.profession}
+                                          onChange={(e) =>
+                                                setForm((f) => ({ ...f, profession: e.target.value }))
+                                    }
+                                    >
+                                          {professions.map((p) => (
+                                                <option key={p} value={p}>
+                                                      {t(`professions.${p}`)}
+                                                </option>
+                                          ))}
+                                    </select>
+
+                                    <input
+                                          type="tel"
+                                          placeholder="MoMo Number"
+                                          value={form.momoNumber}
+                                          onChange={(e) =>
+                                                setForm((f) => ({ ...f, momoNumber: e.target.value }))
+                                          }
+                                    />
+                              </>
+                        )}
+
+                        <select
+                              value={form.quartier}
+                              onChange={(e) => setForm((f) => ({ ...f, quartier: e.target.value }))}
+                        >
+                              {quartiers.map((q) => (
+                                    <option key={q} value={q}>
+                                          {q}
+                                    </option>
+                              ))}
+                        </select>
+
+                        <select
+                              value={form.city}
+                              onChange={(e) => setForm((f) => ({ ...f, city: e.target.value }))}
+                        >
+                              <option value="Yaoundé">Yaoundé</option>
+                              <option value="Douala">Douala</option>
+                        </select>
+
+                        <input
+                              type="text"
+                              placeholder="Country"
+                              value={form.country}
+                              onChange={(e) => setForm((f) => ({ ...f, country: e.target.value }))}
+                        />
+                  </div>
+
+                  <label className={cls.fileLabel}>
+                        <input
+                              type="file"
+                              accept="image/*"
+                              className={cls.fileInput}
+                              onChange={(e) => setPhoto(e.target.files?.[0] || null)}
+                        />
+                        {photo ? 'Change photo' : 'Upload photo'}
+                  </label>
+                  {photo && <div className={cls.fileName}>{photo.name}</div>}
+
                   <button type="submit">Register</button>
             </form>
       );

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -6,6 +6,7 @@ import cls from './Register.module.scss';
 const Register = () => {
       const { t } = useTranslation();
 
+      // available districts for the address selector
       const quartiers = [
             'Mendong',
             'Odja',
@@ -23,6 +24,7 @@ const Register = () => {
             'Biyem-Assi',
             'Autre'
       ];
+      // professions available when the user registers as a provider
       const professions = [
             'plumber',
             'electrician',
@@ -33,12 +35,14 @@ const Register = () => {
             'carpenter',
             'other'
       ];
+      // registration form state
       const [form, setForm] = useState({
             gender: 'male',
             name: '',
             email: '',
             phone: '',
             password: '',
+            confirmPassword: '',
             role: 'client',
             profession: professions[0],
             momoNumber: '',
@@ -48,10 +52,17 @@ const Register = () => {
       });
       const [photo, setPhoto] = useState<File | null>(null);
 
+      // send form data to the API and create the user
       const submit = async (e: React.FormEvent) => {
             e.preventDefault();
+            if (form.password !== form.confirmPassword) {
+                  alert('Passwords do not match'); // warn user before sending
+                  return;
+            }
             const fd = new FormData();
-            Object.entries(form).forEach(([k, v]) => fd.append(k, v));
+            // omit confirmPassword when sending to the API
+            const { confirmPassword, ...payload } = form;
+            Object.entries(payload).forEach(([k, v]) => fd.append(k, v));
             if (photo) fd.append('photo', photo);
             await api.post('/auth/register', fd, {
                   headers: { 'Content-Type': 'multipart/form-data' }
@@ -59,23 +70,24 @@ const Register = () => {
             alert('Compte créé ! Vérifie tes mails.');
       };
 
+      // render the registration form
       return (
             <form className={cls.form} onSubmit={submit}>
-                  <h1>Register</h1>
+                  <h1>{t('register.title')}</h1>
 
                   <div className={cls.fieldsGrid}>
                         <select
                               value={form.gender}
                               onChange={(e) => setForm((f) => ({ ...f, gender: e.target.value }))}
                         >
-                              <option value="male">Male</option>
-                              <option value="female">Female</option>
-                              <option value="other">Other</option>
+                              <option value="male">{t('genders.male')}</option>
+                              <option value="female">{t('genders.female')}</option>
+                              <option value="other">{t('genders.other')}</option>
                         </select>
 
                         <input
                               type="text"
-                              placeholder="Name"
+                              placeholder={t('register.name')}
                               required
                               value={form.name}
                               onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
@@ -83,7 +95,7 @@ const Register = () => {
 
                         <input
                               type="email"
-                              placeholder="Email"
+                              placeholder={t('register.email')}
                               required
                               value={form.email}
                               onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))}
@@ -91,7 +103,7 @@ const Register = () => {
 
                         <input
                               type="tel"
-                              placeholder="Phone"
+                              placeholder={t('register.phone')}
                               required
                               value={form.phone}
                               onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))}
@@ -99,18 +111,26 @@ const Register = () => {
 
                         <input
                               type="password"
-                              placeholder="Password"
+                              placeholder={t('register.password')}
                               required
                               value={form.password}
                               onChange={(e) => setForm((f) => ({ ...f, password: e.target.value }))}
+                        />
+
+                        <input
+                              type="password"
+                              placeholder={t('register.confirmPassword')}
+                              required
+                              value={form.confirmPassword}
+                              onChange={(e) => setForm((f) => ({ ...f, confirmPassword: e.target.value }))}
                         />
 
                         <select
                               value={form.role}
                               onChange={(e) => setForm((f) => ({ ...f, role: e.target.value }))}
                         >
-                              <option value="client">Client</option>
-                              <option value="provider">Provider</option>
+                              <option value="client">{t('roles.client')}</option>
+                              <option value="provider">{t('roles.provider')}</option>
                         </select>
 
                         {form.role === 'provider' && (
@@ -130,7 +150,7 @@ const Register = () => {
 
                                     <input
                                           type="tel"
-                                          placeholder="MoMo Number"
+                                          placeholder={t('register.momoNumber')}
                                           value={form.momoNumber}
                                           onChange={(e) =>
                                                 setForm((f) => ({ ...f, momoNumber: e.target.value }))
@@ -160,7 +180,7 @@ const Register = () => {
 
                         <input
                               type="text"
-                              placeholder="Country"
+                              placeholder={t('register.country')}
                               value={form.country}
                               onChange={(e) => setForm((f) => ({ ...f, country: e.target.value }))}
                         />
@@ -173,11 +193,11 @@ const Register = () => {
                               className={cls.fileInput}
                               onChange={(e) => setPhoto(e.target.files?.[0] || null)}
                         />
-                        {photo ? 'Change photo' : 'Upload photo'}
+                        {photo ? t('register.changePhoto') : t('register.uploadPhoto')}
                   </label>
                   {photo && <div className={cls.fileName}>{photo.name}</div>}
 
-                  <button type="submit">Register</button>
+                  <button type="submit">{t('register.title')}</button>
             </form>
       );
 };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -18,6 +18,27 @@
         "carpenter": "Carpenter",
         "other": "Other"
       },
+      "genders": {
+        "male": "Male",
+        "female": "Female",
+        "other": "Other"
+      },
+      "roles": {
+        "client": "Client",
+        "provider": "Provider"
+      },
+      "register": {
+        "title": "Register",
+        "name": "Name",
+        "email": "Email",
+        "phone": "Phone",
+        "password": "Password",
+        "confirmPassword": "Confirm password",
+        "momoNumber": "MoMo Number",
+        "country": "Country",
+        "uploadPhoto": "Upload photo",
+        "changePhoto": "Change photo"
+      },
       "createAccount": "Create an account",
       "noAccount": "No account yet?"
 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -16,9 +16,30 @@
         "maid": "Femme de ménage",
         "painter": "Peintre",
         "carpenter": "Charpentier",
-      "other": "Autre"
-    },
-    "createAccount": "Créer un compte",
-    "noAccount": "Pas encore de compte ?"
+        "other": "Autre"
+      },
+      "genders": {
+        "male": "Homme",
+        "female": "Femme",
+        "other": "Autre"
+      },
+      "roles": {
+        "client": "Client",
+        "provider": "Prestataire"
+      },
+      "register": {
+        "title": "Inscription",
+        "name": "Nom",
+        "email": "Email",
+        "phone": "Téléphone",
+        "password": "Mot de passe",
+        "confirmPassword": "Confirmer le mot de passe",
+        "momoNumber": "Numéro MoMo",
+        "country": "Pays",
+        "uploadPhoto": "Choisir une photo",
+        "changePhoto": "Changer la photo"
+      },
+      "createAccount": "Créer un compte",
+      "noAccount": "Pas encore de compte ?"
   }
     


### PR DESCRIPTION
## Summary
- add gender, role, profession and address selections to the registration page
- allow uploading a profile picture with a nice label

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552c7820788330a4740bb60893e08b