### PR TITLE
Improve login handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ export default tseslint.config({
   },
 })
 ```
+
+## API Configuration
+
+Create a `.env` file at the project root and define the backend URL used by Axios:
+
+```bash
+VITE_API_URL=http://localhost:3000
+```
+
+Without this variable, requests like login will target the current origin and may fail.

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -20,13 +20,19 @@ export const useAuthStore = create<AuthState>((set) => ({
       user: null,
       token: localStorage.getItem('token'),
       login: async (email, password) => {
-            const res = await api.post('/auth/login', { email, password });
-            const { token } = res.data;
-            localStorage.setItem('token', token);
-            set({ token });
-            // Fetch /me profile
-            const me = await api.get('/auth/me').then((r) => r.data.data);
-            set({ user: me });
+            try {
+                  const res = await api.post('/auth/login', { email, password });
+                  const { token } = res.data;
+                  localStorage.setItem('token', token);
+                  set({ token });
+                  // Fetch /me profile
+                  const me = await api.get('/auth/me').then((r) => r.data.data);
+                  set({ user: me });
+            } catch (err: any) {
+                  console.error('Login failed', err);
+                  alert(err?.response?.data?.message || 'Erreur lors de la connexion');
+                  throw err;
+            }
       },
       logout: () => {
             localStorage.removeItem('token');


### PR DESCRIPTION
## Summary
- add example .env with API URL
- mention API URL setup in README
- handle login errors in auth store

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556aad3b348330951eb2e6610dfa4a